### PR TITLE
refactor: share supabase user helper

### DIFF
--- a/api/_utils.js
+++ b/api/_utils.js
@@ -1,3 +1,5 @@
+import { createClient } from '@supabase/supabase-js';
+
 export const json = (code, data) => ({
   statusCode: code,
   headers: {
@@ -19,6 +21,12 @@ export async function getUserFromAuth(event) {
   });
   if (!r.ok) throw new Error('INVALID_TOKEN');
   return await r.json(); // { id, ... }
+}
+
+export async function getSupabaseUser(event) {
+  const user = await getUserFromAuth(event);
+  const client = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  return { client, user };
 }
 
 export function clientIp(event){


### PR DESCRIPTION
## Summary
- create shared `getSupabaseUser` helper that returns Supabase client and authenticated user
- refactor event endpoints to reuse helper instead of manual token parsing and client creation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a231e012ac833381c2fa31925d3d72