### PR TITLE
Ensure unique event join codes

### DIFF
--- a/api/create-event.js
+++ b/api/create-event.js
@@ -12,7 +12,16 @@ export async function handler(event) {
     const { data: { user } } = await client.auth.getUser(token);
     if (!user) return { statusCode: 401, body: 'Unauthorized' };
 
-    const join_code = Math.floor(100000 + Math.random()*900000).toString();
+    let join_code;
+    while (true) {
+      join_code = Math.floor(100000 + Math.random() * 900000).toString();
+      const { data: existing } = await client
+        .from('events')
+        .select('id')
+        .eq('join_code', join_code)
+        .maybeSingle();
+      if (!existing) break;
+    }
     const event_at = date && time ? new Date(`${date}T${time}:00`).toISOString() : null;
     const payload = { owner_id: user.id, title, address, dress: dress_code, bring, notes, join_code, event_at };
     const { data, error } = await client.from('events').insert(payload).select('*').single();

--- a/migrations/events_join_code_unique.sql
+++ b/migrations/events_join_code_unique.sql
@@ -1,0 +1,2 @@
+-- ensure unique index on events.join_code
+create unique index if not exists events_join_code_key on events(join_code);


### PR DESCRIPTION
## Summary
- Guard against join code collisions by checking existing events before inserting
- Add database migration to enforce unique join code index

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a231de109c8333af9bd4dd97e4d82a