### PR TITLE
feat: secure auth cookies

### DIFF
--- a/api/local-logout.js
+++ b/api/local-logout.js
@@ -2,10 +2,11 @@ export async function handler(event) {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, body: 'Method Not Allowed' };
   }
+  const domain = process.env.COOKIE_DOMAIN ? `Domain=${process.env.COOKIE_DOMAIN}; ` : '';
   return {
     statusCode: 204,
     headers: {
-      'Set-Cookie': 'sb-access-token=; HttpOnly; Path=/; Max-Age=0'
+      'Set-Cookie': `sb-access-token=; ${domain}HttpOnly; Path=/; Max-Age=0; Secure; SameSite=Lax`
     }
   };
 }


### PR DESCRIPTION
## Summary
- include Secure and SameSite=Lax flags on local auth cookies
- optionally set cookie Domain for subdomain usage
- apply same attributes when clearing the session cookie

## Testing
- `npm test`
- `node --check api/local-login.js`
- `node --check api/local-signup.js`
- `node --check api/local-logout.js`


------
https://chatgpt.com/codex/tasks/task_e_68a231db3d8c8333aac398feb4942e4d