### PR TITLE
feat: support service role env fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,20 @@ psql "$SUPABASE_DB_URL" < supabase.sql
 ```
 
 ## Netlify functions
-Two serverless functions use the service role key to interact with Supabase:
+Two serverless functions use the service role key (`SUPABASE_SERVICE_ROLE_KEY`) to interact with Supabase:
 
 - `api/join-by-code.js` – joins the current user to an event by code.
 - `api/event-by-code.js` – returns event information, participants and wishlist.
 
-Configure the connection credentials in `netlify.toml`:
+Configure the connection credentials in `netlify.toml` or the Netlify dashboard:
 
 ```toml
 [build.environment]
 SUPABASE_URL = "..."
 SUPABASE_SERVICE_ROLE_KEY = "..."
 ```
+
+The former `SUPABASE_SERVICE_KEY` name is still accepted as a fallback for older deployments.
 
 ## Secondary sync (Neon)
 

--- a/api/_utils.js
+++ b/api/_utils.js
@@ -13,7 +13,7 @@ export async function getUserFromAuth(event) {
   if (!token) throw new Error('NO_TOKEN');
 
   const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_KEY;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_SERVICE_KEY;
   const r = await fetch(`${url}/auth/v1/user`, {
     headers: { apikey: key, Authorization: `Bearer ${token}` }
   });


### PR DESCRIPTION
## Summary
- use `SUPABASE_SERVICE_ROLE_KEY` with fallback for auth helper
- document single service role key environment variable for deployment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a231d8c9888333a401e418375a5ee9