### PR TITLE
Use nickname instead of username in auth APIs

### DIFF
--- a/api/local-signup.js
+++ b/api/local-signup.js
@@ -7,23 +7,24 @@ export async function handler(event) {
     return { statusCode: 405, body: 'Method Not Allowed' };
   }
   try {
-    const { username, password } = JSON.parse(event.body || '{}');
-    if (!username || !password) return { statusCode: 400, body: 'username and password required' };
-    if (!/^[a-zA-Z0-9_]{3,32}$/.test(username) || password.length < 4) {
-      return { statusCode: 400, body: 'invalid username or password' };
+    const { nickname: nicknameFromBody, username, password } = JSON.parse(event.body || '{}');
+    const nickname = nicknameFromBody ?? username;
+    if (!nickname || !password) return { statusCode: 400, body: 'nickname and password required' };
+    if (!/^[a-zA-Z0-9_]{3,32}$/.test(nickname) || password.length < 4) {
+      return { statusCode: 400, body: 'invalid nickname or password' };
     }
     const client = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
-    const { count } = await client.from('local_users').select('id', { count: 'exact', head: true }).eq('username', username);
-    if (count && count > 0) return { statusCode: 409, body: 'username taken' };
+    const { count } = await client.from('local_users').select('id', { count: 'exact', head: true }).eq('nickname', nickname);
+    if (count && count > 0) return { statusCode: 409, body: 'nickname taken' };
     const password_hash = await bcrypt.hash(password, 10);
-    const { data, error } = await client.from('local_users').insert({ username, password_hash }).select('id, username').single();
+    const { data, error } = await client.from('local_users').insert({ nickname, password_hash }).select('id, nickname').single();
     if (error) throw error;
     const access_token = jwt.sign({ sub: data.id, role: 'authenticated' }, process.env.SUPABASE_JWT_SECRET, { expiresIn: '1h' });
     const headers = {
       'Content-Type': 'application/json',
       'Set-Cookie': `sb-access-token=${access_token}; HttpOnly; Path=/; Max-Age=3600`
     };
-    return { statusCode: 200, headers, body: JSON.stringify({ access_token, user: data }) };
+    return { statusCode: 200, headers, body: JSON.stringify({ access_token, user: { id: data.id, nickname: data.nickname } }) };
   } catch (err) {
     return { statusCode: 500, body: err.message };
   }


### PR DESCRIPTION
## Summary
- switch local-login and local-signup functions to use `nickname` instead of `username`
- accept `username` for backwards compatibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a231d5bdec83339c366a7cfc270735