### PR TITLE
Use username for login

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -28,8 +28,8 @@
       </div>
 
       <section id="pane-login" class="pane grid" role="tabpanel" aria-labelledby="tab-login">
-        <label>Никнейм
-          <input id="login-nickname" type="text" placeholder="Никнейм" required autocomplete="username">
+        <label>Имя пользователя
+          <input id="login-username" type="text" placeholder="Имя пользователя" required autocomplete="username">
         </label>
         <label>Пароль
           <input id="login-password" type="password" placeholder="••••••••" minlength="4" required autocomplete="current-password">
@@ -49,7 +49,7 @@
 
       <section id="pane-register" class="pane grid is-hidden" role="tabpanel" aria-labelledby="tab-register">
         <label>Имя / Никнейм
-          <input id="signup-nickname" required minlength="2" autocomplete="nickname">
+          <input id="signup-username" required minlength="2" autocomplete="nickname">
         </label>
         <label>Пароль
           <input id="signup-password" type="password" required minlength="4" autocomplete="new-password">

--- a/api/auth-login.js
+++ b/api/auth-login.js
@@ -4,15 +4,15 @@ import bcrypt from 'bcryptjs';
 
 export async function handler(event){
   if(event.httpMethod!=='POST') return bad(405,'Method not allowed');
-  const { nickname, password } = JSON.parse(event.body||'{}');
-  if(!nickname || !password) return bad(400,'Неверные данные');
+  const { username, password } = JSON.parse(event.body||'{}');
+  if(!username || !password) return bad(400,'Неверные данные');
   try{
-    const rows = await sql`select id, password_hash from users_local where nickname = ${nickname} limit 1`;
-    if(!rows.length) return bad(401,'Неверный ник или пароль');
+    const rows = await sql`select id, password_hash from local_users where username = ${username} limit 1`;
+    if(!rows.length) return bad(401,'Неверный логин или пароль');
     const okPass = await bcrypt.compare(password, rows[0].password_hash);
-    if(!okPass) return bad(401,'Неверный ник или пароль');
+    if(!okPass) return bad(401,'Неверный логин или пароль');
     // простая сессия в localStorage на фронте — вернём минимум
-    return ok({ user:{ id: rows[0].id, nickname }});
+    return ok({ user:{ id: rows[0].id, username }});
   }catch(e){
     console.error('auth-login', e);
     return bad(500,'Не удалось войти');

--- a/api/auth-register.js
+++ b/api/auth-register.js
@@ -4,14 +4,14 @@ import bcrypt from 'bcryptjs';
 
 export async function handler(event){
   if(event.httpMethod!=='POST') return bad(405,'Method not allowed');
-  const { nickname, password } = JSON.parse(event.body||'{}');
-  if(!nickname || !password || password.length<4) return bad(400,'Неверные данные');
+  const { username, password } = JSON.parse(event.body||'{}');
+  if(!username || !password || password.length<4) return bad(400,'Неверные данные');
   try{
     const hash = await bcrypt.hash(password, 10);
-    await sql`insert into users_local (nickname, password_hash) values (${nickname}, ${hash})`;
-    return ok({ user:{ nickname }});
+    await sql`insert into local_users (username, password_hash) values (${username}, ${hash})`;
+    return ok({ user:{ username }});
   }catch(e){
-    if(String(e?.message||'').includes('duplicate key')) return bad(409,'Ник уже занят');
+    if(String(e?.message||'').includes('duplicate key')) return bad(409,'Логин уже занят');
     console.error('auth-register', e);
     return bad(500,'Не удалось зарегистрироваться');
   }

--- a/migrations/users_local.sql
+++ b/migrations/users_local.sql
@@ -1,9 +1,9 @@
-create table if not exists users_local (
+create table if not exists local_users (
   id bigserial primary key,
-  nickname text not null unique,
+  username text not null unique,
   password_hash text not null,
   created_at timestamptz not null default now()
 );
 
--- ensure unique index on nickname
-create unique index if not exists users_local_nickname_key on users_local(nickname);
+-- ensure unique index on username
+create unique index if not exists local_users_username_key on local_users(username);

--- a/netlify/functions/local-login.js
+++ b/netlify/functions/local-login.js
@@ -11,8 +11,8 @@ exports.handler = async (event) => {
     let payload = {};
     try { payload = JSON.parse(event.body || '{}'); } catch { return err('Invalid JSON body', 400); }
 
-    const { nickname, password } = payload;
-    if (!nickname || !password) return err('Missing nickname or password', 400);
+    const { username, password } = payload;
+    if (!username || !password) return err('Missing username or password', 400);
 
     const conn = process.env.DATABASE_URL;
     if (!conn) return err('DATABASE_URL is not set', 500);
@@ -21,8 +21,8 @@ exports.handler = async (event) => {
     await client.connect();
 
     const { rows } = await client.query(
-      'SELECT id, nickname, password_hash FROM public.users_local WHERE nickname=$1 LIMIT 1',
-      [nickname]
+      'SELECT id, username, password_hash FROM public.local_users WHERE username=$1 LIMIT 1',
+      [username]
     );
 
     if (!rows[0]) { await client.end(); return err('User not found', 401); }
@@ -34,9 +34,9 @@ exports.handler = async (event) => {
     await client.end();
 
     // JWT
-    const token = signToken({ sub: user.id, nickname: user.nickname });
+    const token = signToken({ sub: user.id, username: user.username });
 
-    return ok({ success: true, token, user: { id: user.id, nickname: user.nickname } });
+    return ok({ success: true, token, user: { id: user.id, username: user.username } });
   } catch (e) {
     console.error('local-login error:', e && (e.stack || e.message || e));
     return err(e && e.message ? e.message : 'Internal error', 500);

--- a/netlify/functions/local-signup.js
+++ b/netlify/functions/local-signup.js
@@ -31,8 +31,8 @@ exports.handler = async (event) => {
       return err('Invalid JSON body', 400);
     }
 
-    const { nickname, password, email } = payload;
-    if (!nickname || !password) return err('Missing nickname or password', 400);
+    const { username, password, email } = payload;
+    if (!username || !password) return err('Missing username or password', 400);
 
     const conn = process.env.DATABASE_URL;
     if (!conn) return err('DATABASE_URL is not set', 500);
@@ -51,16 +51,16 @@ exports.handler = async (event) => {
     let result;
     try {
       result = await client.query(
-        `INSERT INTO public.users_local (nickname, email, password_hash)
+        `INSERT INTO public.local_users (username, email, password_hash)
          VALUES ($1, $2, $3)
-         RETURNING id, nickname, email, created_at`,
-        [nickname, email || null, passwordHash]
+         RETURNING id, username, email, created_at`,
+        [username, email || null, passwordHash]
       );
     } catch (e) {
       // PG duplicate key
       if (e && e.code === '23505') {
         await client.end();
-        return err('Nickname already exists', 409);
+        return err('Username already exists', 409);
       }
       throw e;
     }

--- a/netlify/functions/login.ts
+++ b/netlify/functions/login.ts
@@ -30,8 +30,8 @@ export const handler: Handler = async (event) => {
   }
 
   try {
-    const { nickname, password } = JSON.parse(event.body || '{}')
-    if (!nickname || !password) {
+    const { username, password } = JSON.parse(event.body || '{}')
+    if (!username || !password) {
       return err('Некорректные данные')
     }
 
@@ -39,8 +39,8 @@ export const handler: Handler = async (event) => {
 
     try {
       const { rows } = await client.query(
-        'SELECT id, nickname, password_hash FROM users_local WHERE nickname=$1 LIMIT 1',
-        [nickname]
+        'SELECT id, username, password_hash FROM local_users WHERE username=$1 LIMIT 1',
+        [username]
       )
       if (rows.length === 0) {
         return err('Пользователь не найден', 401)
@@ -51,11 +51,11 @@ export const handler: Handler = async (event) => {
         return err('Неверный пароль', 401)
       }
       const token = jwt.sign(
-        { sub: user.id, nickname: user.nickname },
+        { sub: user.id, username: user.username },
         process.env.JWT_SECRET as string,
         { expiresIn: '7d' }
       )
-      return ok({ ok: true, token, user: { id: user.id, nickname: user.nickname } })
+      return ok({ ok: true, token, user: { id: user.id, username: user.username } })
     } catch (e) {
       return err('Ошибка сервера', 500)
     } finally {

--- a/netlify/functions/profile.js
+++ b/netlify/functions/profile.js
@@ -14,7 +14,7 @@ async function handler(event, context) {
   try {
     // context.user.sub — id из токена
     const { rows } = await client.query(
-      'SELECT id, nickname, email, created_at FROM public.users_local WHERE id = $1 LIMIT 1',
+      'SELECT id, username, email, created_at FROM public.local_users WHERE id = $1 LIMIT 1',
       [context.user.sub]
     );
     if (!rows[0]) return err('User not found', 404);

--- a/netlify/functions/signup.ts
+++ b/netlify/functions/signup.ts
@@ -29,8 +29,8 @@ export const handler: Handler = async (event) => {
   }
 
   try {
-    const { nickname, password } = JSON.parse(event.body || '{}')
-    if (!nickname || !password) {
+    const { username, password } = JSON.parse(event.body || '{}')
+    if (!username || !password) {
       return err('Некорректные данные')
     }
 
@@ -39,13 +39,13 @@ export const handler: Handler = async (event) => {
     try {
       const hash = await bcrypt.hash(password, 10)
       await client.query(
-        'INSERT INTO users_local (nickname, password_hash) VALUES ($1, $2)',
-        [nickname, hash]
+        'INSERT INTO local_users (username, password_hash) VALUES ($1, $2)',
+        [username, hash]
       )
       return ok({ ok: true, message: 'Регистрация успешна' })
     } catch (e: any) {
       if (e.code === '23505') {
-        return err('Такой ник уже есть')
+        return err('Такой логин уже есть')
       }
       return err('Ошибка сервера', 500)
     } finally {

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,8 +5,8 @@ const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || '/.netlify/functions'
 });
 
-export const login = async (nickname: string, password: string) => {
-  const { data } = await api.post('/local-login', { nickname, password });
+export const login = async (username: string, password: string) => {
+  const { data } = await api.post('/local-login', { username, password });
   if (data?.token) localStorage.setItem('token', data.token);
   return data;
 };

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -2,12 +2,12 @@
 import { login } from '../api';
 
 export async function doLogin(
-  nickname: string,
+  username: string,
   password: string,
   setMsg: (s: string) => void
 ) {
   try {
-    const res = await login(nickname, password);
+    const res = await login(username, password);
     setMsg('Вход выполнен');
   } catch (e: any) {
     setMsg(e?.response?.data?.error || 'Ошибка входа');


### PR DESCRIPTION
## Summary
- switch client and server auth flows from `nickname` to `username`
- update database migration and queries to use `local_users.username`
- keep `nickname` only for profile display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a237742d288333b92cb23856ba4bef